### PR TITLE
Add support for appsettings.ENVIRONMENT.json files

### DIFF
--- a/src/Resharper.ConfigurationSense/Constants/FileNames.cs
+++ b/src/Resharper.ConfigurationSense/Constants/FileNames.cs
@@ -6,6 +6,9 @@
 
         public const string NetCoreAppSettingsJson = "appsettings.json";
 
+        /*language=regexp*/
+        public const string NetCoreAppSettingsEnvironmentJsonRegex = @"^appsettings\..+\.json$";
+
         public const string NetCoreProjectJson = "project.json";
 
         public const string UserSecretsPathFormat = @"{0}\microsoft\UserSecrets\{1}\secrets.json";

--- a/src/Resharper.ConfigurationSense/Extensions/ProjectExtensions.cs
+++ b/src/Resharper.ConfigurationSense/Extensions/ProjectExtensions.cs
@@ -27,7 +27,7 @@ namespace Resharper.ConfigurationSense.Extensions
         {
             var configFiles = GetNetCoreJsonConfigFiles(project);
 
-            var settings = new Dictionary<string, IList<string>>();
+            var settings = new Dictionary<string, LinkedList<string>>();
             foreach (var projectFile in configFiles)
             {
                 var json = ParseJsonProjectFile(projectFile);

--- a/src/Resharper.ConfigurationSense/Extensions/ProjectExtensions.cs
+++ b/src/Resharper.ConfigurationSense/Extensions/ProjectExtensions.cs
@@ -82,12 +82,13 @@ namespace Resharper.ConfigurationSense.Extensions
                         }
                     }
 
-                    if (!settings.ContainsKey(formattedPath))
+                    if (!settings.TryGetValue(formattedPath, out var settingValues))
                     {
-                        settings.Add(formattedPath, new List<string>());
+                        settingValues = new LinkedList<string>();
+                        settings.Add(formattedPath, settingValues);
                     }
 
-                    settings[formattedPath].Add(property.Value.ToString());
+                    settingValues.AddLast(property.Value.ToString());
                 }
             }
 

--- a/src/Resharper.ConfigurationSense/Settings/OptionsPage.cs
+++ b/src/Resharper.ConfigurationSense/Settings/OptionsPage.cs
@@ -47,7 +47,7 @@ namespace Resharper.ConfigurationSense.Settings
             var customConfigurationFiles = new StringCollectionEditViewModel(
                 lifetime,
                 @"Additional configuration files. 
-You don't need to add appsettings.json, web.config and app.config to the list, they're scanned by default. 
+You don't need to add appsettings.json, appsettings.ENVIRONMENT.json, web.config and app.config to the list, they're scanned by default.
 Only *.json and *.xml files are supported.",
                 buttonProviderFactory,
                 editItemViewModelFactory);


### PR DESCRIPTION
I found it cumbersome manually having to add each of your `appsettings.ENVIRONMENT.json` config files for each of your projects.

With this commit files matching the pattern `appsettings.*.json` is also scanned.

I also attempted to clean up the autocomplete list by merging the values into a comma-separated string so the user can see the available options.