### PR TITLE
Update Rider version to support 2019.3

### DIFF
--- a/src/rider-configuration-sense/META-INF/plugin.xml
+++ b/src/rider-configuration-sense/META-INF/plugin.xml
@@ -4,7 +4,7 @@
   <description>This extension provides autocomplete and validation for App settings and Connection strings.</description>
   <version>2017.2.2.0</version>
   <vendor url="https://github.com/olsh/resharper-configuration-sense">Oleg Shevchenko</vendor>
-  <idea-version since-build="192" until-build="192.*"/>
+  <idea-version since-build="193" until-build="193.*"/>
   <extensions defaultExtensionNs="com.intellij" />
   <depends>com.intellij.modules.rider</depends>
 </idea-plugin>


### PR DESCRIPTION
Currently Rider plugin claims it's only compatible with 2019.2 — 2019.2.3
https://plugins.jetbrains.com/plugin/10118-configuration-sense/versions