### PR TITLE
Update JetBrains SDK to 2021.1

### DIFF
--- a/src/Resharper.ConfigurationSense/Resharper.ConfigurationSense.Rider.csproj
+++ b/src/Resharper.ConfigurationSense/Resharper.ConfigurationSense.Rider.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net461</TargetFramework>
-    <VersionPrefix>2020.3.0</VersionPrefix>
+    <VersionPrefix>2021.1.0</VersionPrefix>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
   <PropertyGroup>
@@ -11,6 +11,6 @@
     <RootNamespace>Resharper.ConfigurationSense</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="JetBrains.Rider.SDK" Version="2020.3.0" />
+    <PackageReference Include="JetBrains.Rider.SDK" Version="2021.1.0" />
   </ItemGroup>
 </Project>

--- a/src/Resharper.ConfigurationSense/Resharper.ConfigurationSense.csproj
+++ b/src/Resharper.ConfigurationSense/Resharper.ConfigurationSense.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net461</TargetFramework>
-    <VersionPrefix>2020.3.0</VersionPrefix>
+    <VersionPrefix>2021.1.0</VersionPrefix>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
   <PropertyGroup>
     <SonarQubeTestProject>false</SonarQubeTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="JetBrains.ReSharper.SDK" Version="2020.3.0" />
+    <PackageReference Include="JetBrains.ReSharper.SDK" Version="2021.1.0" />
   </ItemGroup>
 </Project>

--- a/src/rider-configuration-sense/META-INF/plugin.xml
+++ b/src/rider-configuration-sense/META-INF/plugin.xml
@@ -4,7 +4,7 @@
   <description>This extension provides autocomplete and validation for App settings and Connection strings.</description>
   <version>2017.2.2.0</version>
   <vendor url="https://github.com/olsh/resharper-configuration-sense">Oleg Shevchenko</vendor>
-  <idea-version since-build="203" until-build="203.*"/>
+  <idea-version since-build="211" until-build="211.*"/>
   <extensions defaultExtensionNs="com.intellij" />
   <depends>com.intellij.modules.rider</depends>
 </idea-plugin>


### PR DESCRIPTION
- Update wave version to 211
- Update JetBrains.ReSharper.SDK version to 2021.1.0
- Update JetBrains.Rider.SDK version to 2021.1.0

Resolves #17
Resolves #18