### PR TITLE
Show the options page in Rider and drop the obsolete options API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -270,6 +270,9 @@ build/tmp/
 # Test data
 /test/data/NuGetLocks/
 
+# Scratch solutions for trying the plugin by hand, see AGENTS.md
+/test/data/manual/
+
 # Test results
 /test/results/
 

--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -30,6 +30,7 @@
         "PublishReSharperPlugin",
         "PublishRiderPlugin",
         "Restore",
+        "RunIde",
         "Test"
       ]
     },
@@ -110,6 +111,10 @@
         "MarketplaceToken": {
           "type": "string",
           "default": "Secrets must be entered via 'nuke :secrets [profile]'"
+        },
+        "RunIdeSolution": {
+          "type": "string",
+          "description": "Solution to open in the sandboxed IDE"
         },
         "Solution": {
           "type": "string",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,11 +98,22 @@ Both target `net472` and rely on SDK-style implicit globbing, so **a new `.cs` f
 
 ### Additional configuration files setting
 
-`Settings/ConfigurationSenseSettings` exposes a single `IIndexedEntry<string, string>` keyed by solution id; the value is a JSON-serialized `HashSet<string>` of project-file persistent ids (`OptionsExtensions` handles (de)serialization and resets the entry on parse failure). The ReSharper options page (`Settings/OptionsPage.cs`) edits it with a `StringCollectionEditViewModel`, filtered to JSON/XML project files.
+`Settings/ConfigurationSenseSettings` exposes a single `IIndexedEntry<string, string>` keyed by solution id; the value is a JSON-serialized `HashSet<string>` of project-file persistent ids (`OptionsExtensions` handles (de)serialization and resets the entry on parse failure). The options page (`Settings/OptionsPage.cs`) edits it as a Be list, filtered to JSON/XML project files, and writes the whole set back in `OnOk()` - so Cancel discards edits.
+
+The Add button is a native file dialog seeded at the solution directory, not a solution-tree browser: no Be control browses the project model, so the picked path is mapped back onto it the way the SDK's own `OptionsTableConfiguration.LoadFilesAndDirsToolbar` does (`ParseVirtualPathSafe` -> `FindProjectItemsByLocation` -> `GetPersistentID`).
 
 ### Rider frontend
 
-`src/rider/main/kotlin/` contains a `SimpleOptionsPage` subclass, but **it is not registered** - the `applicationConfigurable` entry in `plugin.xml` is commented out because `StringCollectionEditViewModel` isn't supported in Rider. So the Kotlin side is currently inert scaffolding; the Rider plugin is effectively just the backend `.dll`, copied into `<plugin>/dotnet` by Gradle's `prepareSandbox` (which fails the build if the dll/pdb is missing). It still has to compile, though: `SimpleOptionsPage` lives in the `intellij.rider.rdclient.dotnet` bundled module, which `build.gradle` declares explicitly - without that `bundledModule` line `compileKotlin` fails with an unresolved reference. The platform stopped exposing it from the main jars somewhere between 253 and 262, so it is easy to trip over on an SDK bump.
+The options page is shared with ReSharper - there is no Rider-specific UI code. `ConfigurationSenseOptionsPage` derives from `JetBrains.IDE.UI.Options.BeSimpleOptionsPage`, so its whole UI is a `BeControl` tree, and Rider's `BeSimpleOptionPageConverter` ships it across the protocol as one `BeSimpleOptionsPageContent`. **Be controls are what make a page cross-IDE**; the WPF automation view models (`StringCollectionEditViewModel` and friends) have no Rider view and render as nothing, which is why this page was Rider-only scaffolding until the port.
+
+`src/rider/main/kotlin/` therefore holds only a host: a `SimpleOptionsPage` subclass registered as a `projectConfigurable` in `plugin.xml` (`projectConfigurable`, not `applicationConfigurable`, because the feature is solution-scoped - that is also how JetBrains registers its own solution-scoped backend pages). Two ids are in play and they are **not** interchangeable:
+
+- the ctor's `pageId` must equal the C# `[OptionsPage]` id **verbatim** (`"Configuration Sense"`, space included) - it is passed straight to `SettingsViewModelHost.requestPage` with no normalization, so a mismatch silently resolves to an empty page;
+- `getId()` / the XML `id=` attribute is the IntelliJ configurable id (`preferences.configurationSense`), a separate namespace.
+
+Everything else is the backend `.dll`, copied into `<plugin>/dotnet` by Gradle's `prepareSandbox` (which fails the build if the dll/pdb is missing). The Kotlin still has to compile: `SimpleOptionsPage` lives in the `intellij.rider.rdclient.dotnet` bundled module, which `build.gradle` declares explicitly - without that `bundledModule` line `compileKotlin` fails with an unresolved reference. The platform stopped exposing it from the main jars somewhere between 253 and 262, so it is easy to trip over on an SDK bump.
+
+Handy check that the wiring survived a change: `buildPlugin` runs `buildSearchableOptions`, which launches Rider headlessly and renders the page. If `lib/*-searchableOptions.jar` contains hit text from the C# page, the whole backend -> protocol -> frontend chain resolved; if the page fails to resolve, that text is missing.
 
 Rider-specific quirk worth knowing: since 2019.1 the Rider backend has no PSI for JSON files, so `ParseJsonProjectFile` falls back to reading document text through `DocumentsOnProjectFiles` when `GetPrimaryPsiFile()` returns null. Keep that fallback when touching JSON reading.
 
@@ -151,6 +162,41 @@ directly and swallows every exception, so it is inert in tests) and the **additi
 files setting** (the stored value is a project file's runtime persistent ID).
 
 Run `build.cmd test` before submitting.
+
+## Manual testing
+
+The options page and the analyzers are checked by hand against a real solution. `test/data/manual/`
+is gitignored scratch space for that (structured-logging keeps a `test/manual/` for the same
+purpose) - put any .NET solution there, or anywhere else, and open it in a sandboxed Rider with the
+plugin installed:
+
+```sh
+./build.cmd RunIde --configuration Debug --run-ide-solution test/data/manual/YourSolution.slnx
+```
+
+`RunIde` depends on `Compile` and derives the same `-P` properties as `PackRider`, so it cannot pick
+up the `_PLACEHOLDER_` values a bare `./gradlew runIde` would. `--run-ide-solution` is optional and
+is forwarded to the IDE as a command-line argument; without it Rider starts with no solution open.
+Pass `--configuration Debug` unless you specifically want a Release backend - the Nuke default is
+`Release`. The target blocks until the IDE is closed, and unlike the pack targets it logs Gradle
+output at Information level so the sandboxed IDE's console stays visible.
+
+A solution is worth keeping around with two projects, one per dispatch path (`ConfigurationManager`
+and `IConfiguration`), each holding a config file the plugin *ignores* by default - something not
+named `app.config`, `web.config` or `appsettings.json`. Those exercise the additional-configuration-
+files setting: their keys stay highlighted until the file is registered on the options page.
+
+Anything placed under `test/data/` needs two stubs next to it, because MSBuild and NuGet both walk
+up the tree - and since the directory is gitignored, these do not survive a fresh clone:
+
+- `Directory.Build.props`, an empty `<Project/>`, so the repository's own props (`SdkVersion` and
+  friends) do not apply to a solution that has nothing to do with building the plugin;
+- `nuget.config` re-adding `https://api.nuget.org/v3/index.json` after a `<clear/>`. `test/data/nuget.config`
+  exists for the `[TestPackages]` restore and clears the source list down to two **HTTP** feeds;
+  inheriting those fails any modern restore with `NU1302: NuGet requires HTTPS sources`.
+
+structured-logging sidesteps both by keeping its scratch solutions in `test/manual/`, outside
+`test/data/` - worth considering if these stubs ever drift.
 
 ## Conventions
 

--- a/build.gradle
+++ b/build.gradle
@@ -75,6 +75,12 @@ prepareSandbox {
     }
 }
 
+runIde {
+    if (project.hasProperty('RunIdeSolution')) {
+        argumentProviders.add({ [project.property('RunIdeSolution').toString()] } as CommandLineArgumentProvider)
+    }
+}
+
 wrapper {
     gradleVersion    = '9.7.1'
     distributionType = Wrapper.DistributionType.ALL

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 
@@ -59,6 +59,9 @@ class Build : NukeBuild
     [Parameter] readonly string Configuration = "Release";
 
     [Parameter] [Secret] readonly string MarketplaceToken;
+
+    [Parameter("Solution to open in the sandboxed IDE")]
+    readonly AbsolutePath RunIdeSolution;
 
     [Solution(GenerateProjects = true)] readonly Solution Solution;
 
@@ -193,6 +196,23 @@ class Build : NukeBuild
                 logger: GradleLogger);
         });
 
+    // Launches a sandboxed Rider with the plugin installed, for trying the options page and the
+    // analyzers by hand - neither has automated coverage. Blocks until the IDE is closed.
+    Target RunIde => _ => _
+        .DependsOn(Compile)
+        .Executes(() =>
+        {
+            var arguments =
+                @$"runIde -PPluginVersion={ExtensionVersion} -PProductVersion={RiderProductVersion} -PDotNetOutputDirectory={Solution.Resharper_ConfigurationSense_Rider.GetOutputDirectory(Configuration)} -PDotNetProjectName={Solution.Resharper_ConfigurationSense_Rider.Name}";
+
+            if (RunIdeSolution != null)
+            {
+                arguments += @$" -PRunIdeSolution={RunIdeSolution}";
+            }
+
+            Gradle(arguments, logger: RunIdeLogger);
+        });
+
     // Both test projects share test/src, so each one writes to bin/<project>/<configuration>.
     // Extensions.GetOutputDirectory hardcodes bin/<configuration> and cannot be used here
     AbsolutePath TestOutputDirectory(Project project) =>
@@ -208,6 +228,10 @@ class Build : NukeBuild
     // Gradle writes warnings to stderr, and the default logger reports stderr as build errors
     // ReSharper disable once TemplateIsNotCompileTimeConstantProblem
     static void GradleLogger(OutputType type, string text) => Log.Debug(text);
+
+    // Same stderr problem, but the whole point of RunIde is watching the IDE, so keep it visible
+    // ReSharper disable once TemplateIsNotCompileTimeConstantProblem
+    static void RunIdeLogger(OutputType type, string text) => Log.Information(text);
 
     // Replaces AppVeyor's UpdateBuildVersion, which used to display the extension version on the
     // build page. GitHub Actions evaluates run-name before any step runs, so the version cannot go

--- a/src/Resharper.ConfigurationSense/Settings/OptionsPage.cs
+++ b/src/Resharper.ConfigurationSense/Settings/OptionsPage.cs
@@ -1,91 +1,160 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 
 using JetBrains.Annotations;
-using JetBrains.Application.Components;
-using JetBrains.Application.UI.Components;
-using JetBrains.Application.UI.Controls.StringCollectionEdit.Impl;
+using JetBrains.Application.Threading;
+using JetBrains.Application.UI.Controls.FileSystem;
+using JetBrains.Application.UI.Icons.CommonThemedIcons;
 using JetBrains.Application.UI.Options;
 using JetBrains.Application.UI.Options.OptionPages;
+using JetBrains.Application.UI.Options.OptionsDialog;
+using JetBrains.DataFlow;
+using JetBrains.IDE.UI;
+using JetBrains.IDE.UI.Extensions;
+using JetBrains.IDE.UI.Options;
 using JetBrains.Lifetimes;
 using JetBrains.ProjectModel;
 using JetBrains.ReSharper.Feature.Services.Resources;
-using JetBrains.ReSharper.Feature.Services.Util.FilesAndDirs;
 using JetBrains.ReSharper.Resources.Shell;
-using JetBrains.ReSharper.UnitTestFramework.UI.Options;
+using JetBrains.Rider.Model.UIAutomation;
+using JetBrains.Util;
 
 using Resharper.ConfigurationSense.Extensions;
 
 namespace Resharper.ConfigurationSense.Settings
 {
     [OptionsPage(PageId, "Configuration Sense", typeof(BulbThemedIcons.YellowBulbVS), ParentId = EnvironmentPage.Pid)]
-    public sealed class ConfigurationSenseOptionsPage : BetterCustomOptionsPage
+    public sealed class ConfigurationSenseOptionsPage : BeSimpleOptionsPage
     {
         private const string PageId = "Configuration Sense";
 
+        [CanBeNull] private readonly ISolution mySolution;
+
+        [CanBeNull] private readonly ListEvents<ConfigurationFileItem> myConfigurationFiles;
+
         public ConfigurationSenseOptionsPage(
             Lifetime lifetime,
+            OptionsPageContext optionsPageContext,
             [NotNull] OptionsSettingsSmartContext optionsSettingsSmartContext,
-            IComponentContainer componentContainer,
-            ProjectModelElementPresentationService presentationService,
-            IUIApplication iuiApplication)
-            : base(lifetime, optionsSettingsSmartContext)
+            IIconHost iconHost,
+            IShellLocks shellLocks,
+            ICommonFileDialogs commonFileDialogs,
+            [CanBeNull] ISolution solution = null)
+            : base(lifetime, optionsPageContext, optionsSettingsSmartContext)
         {
-            var solution = componentContainer.TryGetComponent<ISolution>();
             if (solution == null)
             {
                 AddHeader("To edit the list of additional configuration files you should open a solution.");
                 return;
             }
 
-            var editItemViewModelFactory = new FilesAndDirsCollectionEditItemViewModelFactory(iuiApplication.ShellLocks, presentationService);
-            var buttonProviderFactory = new FilesAndDirsButtonProviderFactory(
-                lifetime,
-                iuiApplication.ShellLocks,
-                solution,
-                editItemViewModelFactory,
-                false);
-
-            var customConfigurationFiles = new StringCollectionEditViewModel(
-                lifetime,
-                @"Additional configuration files.
-You don't need to add appsettings.json, web.config and app.config (and transformation files) to the list, they're scanned by default.
-Only *.json and *.xml files are supported.",
-                buttonProviderFactory,
-                editItemViewModelFactory);
+            mySolution = solution;
+            myConfigurationFiles = ListEvents<ConfigurationFileItem>.Create("ConfigurationSense::ConfigurationFiles");
+            var selectedFile = new Property<ConfigurationFileItem>("ConfigurationSense::SelectedConfigurationFile");
 
             using (ReadLockCookie.Create())
             {
-                foreach (var x in optionsSettingsSmartContext.GetAdditionalConfigurationFiles(solution.GetId()))
+                foreach (var persistentId in optionsSettingsSmartContext.GetAdditionalConfigurationFiles(
+                             solution.GetId()))
                 {
-                    var element = solution.FindElementByPersistentID(x);
+                    var element = solution.FindElementByPersistentID(persistentId);
                     if (element == null)
                     {
                         continue;
                     }
 
-                    customConfigurationFiles.AddItem(element.Name, behindValue: element);
+                    myConfigurationFiles.Add(new ConfigurationFileItem(persistentId, element.Name));
                 }
             }
 
-            customConfigurationFiles.Items.CollectionChanged += (_, _) =>
-                {
-                    var hashSet = new HashSet<string>();
-                    foreach (var item in customConfigurationFiles.Items)
-                    {
-                        var filesAndDirsItem = (FilesAndDirsItemViewModel)item;
-                        if (filesAndDirsItem.ProjectElement is IProjectFile projectFile
-                            && (projectFile.LanguageType.Is<JsonProjectFileType>()
-                                || projectFile.LanguageType.Is<XmlProjectFileType>()))
-                        {
-                            hashSet.Add(projectFile.GetPersistentID());
-                        }
-                    }
+            var toolbar = selectedFile.GetBeSingleSelectionListWithToolbar(
+                myConfigurationFiles,
+                lifetime,
+                (_, item, _) => new List<BeControl> { item.Presentation.GetBeLabel() },
+                iconHost,
+                new[] { "File,*" },
+                hasHeader: false);
 
-                    OptionsSettingsSmartContext.SaveCustomConfigurationFiles(solution.GetId(), hashSet);
-                };
+            var solutionPath = solution.SolutionFilePath.IsEmpty
+                ? solution.SolutionDirectory
+                : solution.SolutionFilePath;
+            var addButton = BeControls.GetPathSelectionButton(
+                string.Empty.GetBeLabel(CommonThemedIcons.Create.Id.GetIcon(iconHost)),
+                BrowsePathOptions.OpenFile,
+                lifetime,
+                commonFileDialogs,
+                solutionPath.ToNativeFileSystemPath(),
+                new[] { new ChooseFileType(new[] { "json", "xml" }, "Configuration files") },
+                BeButtonStyle.ICON,
+                path => shellLocks.ExecuteOrQueueReadLockEx(
+                    lifetime,
+                    "ConfigurationSense::AddConfigurationFile",
+                    () => AddConfigurationFile(path)));
+
+            toolbar
+                .AddItem(addButton)
+                .AddButtonWithListAction<ConfigurationFileItem>(
+                    BeListAction.REMOVE,
+                    index => myConfigurationFiles.RemoveAt(index));
 
             AddHeader("Configuration files");
-            AddCustomOption(customConfigurationFiles);
+            AddCommentText(
+                "You don't need to add appsettings.json, web.config and app.config (and transformation files) to the list, they're scanned by default.");
+            AddCommentText("Only *.json and *.xml files are supported.");
+            AddControl(toolbar, isStar: true);
+        }
+
+        public override bool OnOk()
+        {
+            if (mySolution != null && myConfigurationFiles != null)
+            {
+                var persistentIds = new HashSet<string>(myConfigurationFiles.Select(file => file.PersistentId));
+                OptionsSettingsSmartContext.SaveCustomConfigurationFiles(mySolution.GetId(), persistentIds);
+            }
+
+            return base.OnOk();
+        }
+
+        private void AddConfigurationFile(FileSystemPath path)
+        {
+            var virtualPath = path.FullPath.ParseVirtualPathSafe(InteractionContext.SolutionContext);
+            if (virtualPath.IsEmpty)
+            {
+                return;
+            }
+
+            var projectFile = mySolution.FindProjectItemsByLocation(virtualPath)
+                .OfType<IProjectFile>()
+                .FirstOrDefault();
+            if (projectFile == null
+                || (!projectFile.LanguageType.Is<JsonProjectFileType>()
+                    && !projectFile.LanguageType.Is<XmlProjectFileType>()))
+            {
+                return;
+            }
+
+            var persistentId = projectFile.GetPersistentID();
+            if (myConfigurationFiles.Any(file => file.PersistentId == persistentId))
+            {
+                return;
+            }
+
+            myConfigurationFiles.Add(new ConfigurationFileItem(persistentId, projectFile.Name));
+        }
+
+        private sealed class ConfigurationFileItem
+        {
+            public ConfigurationFileItem([NotNull] string persistentId, [NotNull] string presentation)
+            {
+                PersistentId = persistentId;
+                Presentation = presentation;
+            }
+
+            [NotNull]
+            public string PersistentId { get; }
+
+            [NotNull]
+            public string Presentation { get; }
         }
     }
 }

--- a/src/rider/main/kotlin/com/jetbrains/rider/settings/ConfigurationSensePluginOptionsPage.kt
+++ b/src/rider/main/kotlin/com/jetbrains/rider/settings/ConfigurationSensePluginOptionsPage.kt
@@ -1,13 +1,12 @@
 package com.jetbrains.rider.settings
 
 import com.jetbrains.rider.settings.simple.SimpleOptionsPage
-import com.jetbrains.rider.settings.ConfigurationSenseBundle
 
 class ConfigurationSensePluginOptionsPage : SimpleOptionsPage(
     name = ConfigurationSenseBundle.message("configurable.name.configurationsense.title"),
-    pageId = "ConfigurationSense")
+    pageId = "Configuration Sense")
 {
     override fun getId(): String {
-        return "ConfigurationSense"
+        return "preferences.configurationSense"
     }
 }

--- a/src/rider/main/resources/META-INF/plugin.xml
+++ b/src/rider/main/resources/META-INF/plugin.xml
@@ -7,10 +7,12 @@
   <vendor url="https://github.com/olsh/resharper-configuration-sense">Oleg Shevchenko</vendor>
   <idea-version since-build="" until-build=""/>
   <resource-bundle>messages.ConfigurationSenseBundle</resource-bundle>
-  <extensions defaultExtensionNs="com.intellij" >
-    <!-- StringCollectionEditViewModel is not supported in Rider at the moment, so we can't enable this -->
-    <!--https://jetbrains.slack.com/archives/CBZ36NH7C/p1618820321116500-->
-    <!-- <applicationConfigurable groupId="language" instance="com.jetbrains.rider.settings.ConfigurationSensePluginOptionsPage" id="ConfigurationSense" /> -->
+  <extensions defaultExtensionNs="com.intellij">
+    <projectConfigurable groupId="language"
+                         id="preferences.configurationSense"
+                         instance="com.jetbrains.rider.settings.ConfigurationSensePluginOptionsPage"
+                         bundle="messages.ConfigurationSenseBundle"
+                         key="configurable.name.configurationsense.title"/>
   </extensions>
   <depends>com.intellij.modules.rider</depends>
 </idea-plugin>

--- a/src/rider/main/resources/messages/ConfigurationSenseBundle.properties
+++ b/src/rider/main/resources/messages/ConfigurationSenseBundle.properties
@@ -1,1 +1,1 @@
-configurable.name.configurationsense.title=Structured Logging
+configurable.name.configurationsense.title=Configuration Sense

--- a/test/src/Settings/OptionsPageTests.cs
+++ b/test/src/Settings/OptionsPageTests.cs
@@ -1,0 +1,45 @@
+using JetBrains.Application.Settings;
+using JetBrains.Application.Threading;
+using JetBrains.Application.UI.Controls.FileSystem;
+using JetBrains.Application.UI.Options;
+using JetBrains.Application.UI.Options.OptionsDialog;
+using JetBrains.IDE.UI;
+using JetBrains.ProjectModel;
+using JetBrains.ReSharper.TestFramework;
+
+using NUnit.Framework;
+
+using Resharper.ConfigurationSense.Settings;
+
+namespace Resharper.ConfigurationSense.Tests.Settings
+{
+    // The page builds a Be control tree in its constructor, and several Be constructors reject nulls
+    // at runtime rather than at compile time. Nothing else covers that: the Rider searchable-options
+    // pass renders the page without a solution, so it only ever reaches the "open a solution" branch
+    [TestNet60]
+    public sealed class OptionsPageTests : BaseTestWithSingleProject
+    {
+        protected override string RelativeTestDataPath => @"Settings";
+
+        [Test]
+        public void TestOptionsPageIsBuiltWhenSolutionIsOpen()
+        {
+            DoTestSolution((lifetime, solution) =>
+            {
+                var settingsStore = solution.GetComponent<ISettingsStore>()
+                    .BindToContextLive(lifetime, ContextRange.ApplicationWide);
+
+                var page = new ConfigurationSenseOptionsPage(
+                    lifetime,
+                    new OptionsPageContext(),
+                    new OptionsSettingsSmartContext(settingsStore, settingsStore),
+                    solution.GetComponent<IIconHost>(),
+                    solution.GetComponent<IShellLocks>(),
+                    solution.GetComponent<ICommonFileDialogs>(),
+                    solution);
+
+                Assert.That(page.Content, Is.Not.Null);
+            });
+        }
+    }
+}


### PR DESCRIPTION
Fixes the two Marketplace warnings and gets the options page into Rider. They turn out to be the same change.

## The obsolete API

`SimpleOptionsPage` and `CustomSimpleOptionsPage` are obsolete as of the 2026.2 SDK — *"Use BeSimpleOptionsPage and extend it as necessary; keep the same API if possible"*. `ConfigurationSenseOptionsPage` inherited both through `BetterCustomOptionsPage`.

## Why that also unblocks Rider

`plugin.xml` blamed `StringCollectionEditViewModel` for the page not being registered, and that was right — but the base class was never the blocker:

- `DefaultSimpleOptionsPageConverter` already renders legacy pages in Rider (`TestLinkerOptionsPage` ships as a `BetterCustomOptionsPage`).
- `AddCustomOption` *does* cross the protocol, as an `AutomationOptionItem` — but the frontend draws it through `ViewRegistry`, which only has views for `BeControl`s. `StringCollectionEditViewModel` is a WPF `AAutomation`; the string does not appear anywhere in `Rider.Backend.dll`.
- `BeSimpleOptionPageConverter.Convert` is literally `new BeSimpleOptionsPageContent(((BeSimpleOptionsPage)page).Content)` — a Be page crosses as one `BeControl` tree with no extra plumbing.

So moving off the obsolete base *is* what makes the page renderable in Rider. Same approach the Unity plugin uses, which ships the same way this one does (ReSharper backend `.dll` inside a Rider plugin's `dotnet/`).

## Also fixed

Three latent bugs in the dormant Rider scaffolding:

- the ctor `pageId` was `"ConfigurationSense"` while the backend declares `"Configuration Sense"` — it is matched verbatim by `SettingsViewModelHost.requestPage`, so it resolved to nothing;
- `getId()` reused the backend page id instead of an IntelliJ configurable id (separate namespaces);
- the display name read **"Structured Logging"**.

Registered as `projectConfigurable`, not `applicationConfigurable`, because the feature is solution-scoped — matching how JetBrains registers its own solution-scoped backend pages.

## Behaviour changes

- **Settings are written in `OnOk()`** instead of on every `CollectionChanged`. Cancel now discards edits; previously they were already saved.
- **The picker is a native file dialog** seeded at the solution directory and filtered to `*.json`/`*.xml`, instead of a solution-tree browser. No Be control browses the project model — the SDK's own `LoadFilesAndDirsToolbar` does the same and maps the path back via `FindProjectItemsByLocation` → `GetPersistentID`.

The stored settings format is unchanged, so existing configurations carry over.

## Testing

Added a construction test. It is worth having: the Be constructors reject nulls at *runtime*, so a null button caption compiles cleanly and then throws `ArgumentNullException` only when the page is opened — which is exactly what happened while developing this. Nothing else covers it, because the Rider searchable-options pass renders the page with no solution and so only reaches the "open a solution" branch.

- `build.cmd Test` — 29/29 in both SDK flavours
- `build.cmd PackResharper PackRider` — both green, no obsolete warnings
- Opened by hand in a sandboxed Rider against a real solution: add, remove, OK and Cancel all behave

Also adds a `RunIde` Nuke target for that manual pass, mirroring resharper-structured-logging, since it otherwise means remembering four Gradle properties that `gradle.properties` ships as `_PLACEHOLDER_`:

```sh
./build.cmd RunIde --configuration Debug --run-ide-solution <path>
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned the Configuration Sense settings page with a selectable file list.
  * Add JSON or XML project configuration files using a native file picker, prevent duplicates, and remove entries.
  * Changes are now saved when confirming the settings page.
  * Configuration Sense settings are available at the solution level in Rider.
  * Added support for launching Rider with an optional solution opened automatically.

* **Documentation**
  * Added instructions for manually testing the new settings and Rider launch workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->