### PR TITLE
Automate SDK updates and their releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,9 +16,10 @@ on:
 
 concurrency:
   # A dispatched release gets a group to itself, keyed on the run, so that a push landing while it
-  # publishes cannot cancel it half way through. Push and pull request runs keep superseding theirs
+  # publishes cannot cancel it half way through. Pull request runs keep superseding theirs
   group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  # A push to master can publish too, so those runs are left alone for the same reason
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
@@ -37,10 +38,48 @@ jobs:
 
     outputs:
       version: ${{ steps.version.outputs.value }}
+      publish: ${{ steps.publish-decision.outputs.value }}
 
     steps:
       - name: Check out repository
         uses: actions/checkout@v7
+        with:
+          # The publish decision below compares this commit against the one the push started from
+          fetch-depth: 0
+
+      # A new SDK is the only change that has to reach users as a new build, and it is what the SDK
+      # update workflow merges here, so an SdkVersion change landing on master is a release. Every
+      # other release stays a manual dispatch with the publish input
+      - name: Decide whether to publish
+        id: publish-decision
+        shell: bash
+        env:
+          DISPATCHED_PUBLISH: ${{ inputs.publish }}
+          PUSHED_FROM: ${{ github.event.before }}
+        run: |
+          set -euo pipefail
+
+          read_sdk_version() {
+            sed -n 's:.*<SdkVersion>\(.*\)</SdkVersion>.*:\1:p'
+          }
+
+          publish=false
+
+          # Stripping the zeros empties the all-zero SHA that a branch creation reports, which has no
+          # Directory.Build.props to compare against
+          if [ "$DISPATCHED_PUBLISH" = "true" ]; then
+            publish=true
+          elif [ "$GITHUB_EVENT_NAME" = "push" ] && [ "$GITHUB_REF" = "refs/heads/master" ] && [ -n "${PUSHED_FROM//0/}" ]; then
+            previous=$(git show "$PUSHED_FROM:Directory.Build.props" 2>/dev/null | read_sdk_version || true)
+            current=$(read_sdk_version < Directory.Build.props)
+
+            if [ -n "$previous" ] && [ "$previous" != "$current" ]; then
+              echo "The JetBrains SDK went from $previous to $current, so this push is a release"
+              publish=true
+            fi
+          fi
+
+          echo "value=$publish" >> "$GITHUB_OUTPUT"
 
       - name: Set up .NET
         uses: actions/setup-dotnet@v6
@@ -99,7 +138,7 @@ jobs:
         run: echo "value=$env:EXTENSION_VERSION" >> $env:GITHUB_OUTPUT
 
       - name: Publish to JetBrains Marketplace
-        if: inputs.publish
+        if: steps.publish-decision.outputs.value == 'true'
         env:
           MARKETPLACE_TOKEN: ${{ secrets.JETBRAINS_MARKETPLACE_TOKEN }}
         run: .\build.cmd PublishReSharperPlugin PublishRiderPlugin --configuration Release
@@ -107,7 +146,7 @@ jobs:
   release:
     name: Create GitHub release
     needs: build
-    if: inputs.publish
+    if: needs.build.outputs.publish == 'true'
     runs-on: ubuntu-latest
 
     permissions:

--- a/.github/workflows/sdk-update.yml
+++ b/.github/workflows/sdk-update.yml
@@ -1,0 +1,113 @@
+name: SDK update
+
+on:
+  schedule:
+    # Daily, so that an EAP is picked up the morning after JetBrains publishes it
+    - cron: '0 5 * * *'
+  workflow_dispatch:
+    inputs:
+      sdk-version:
+        description: Adopt this SDK version instead of the one the wave policy picks
+        type: string
+
+concurrency:
+  group: sdk-update
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  DOTNET_CLI_TELEMETRY_OPTOUT: 1
+  DOTNET_NOLOGO: true
+
+jobs:
+  propose:
+    name: Propose SDK update
+    if: github.repository == 'olsh/resharper-configuration-sense'
+    runs-on: ubuntu-latest
+
+    steps:
+      # The pull request has to run the Build workflow, and one opened with the built in token never
+      # triggers a workflow, so the branch and the pull request go through a personal access token
+      - name: Check the automation token
+        env:
+          AUTOMATION_TOKEN: ${{ secrets.AUTOMATION_TOKEN }}
+        run: |
+          if [ -z "$AUTOMATION_TOKEN" ]; then
+            echo "::error::The AUTOMATION_TOKEN secret is missing. Create a fine grained personal access token for this repository with read and write access to contents and pull requests."
+            exit 1
+          fi
+
+      - name: Check out repository
+        uses: actions/checkout@v7
+        with:
+          token: ${{ secrets.AUTOMATION_TOKEN }}
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Look for a newer SDK
+        id: sdk
+        env:
+          SDK_VERSION_OVERRIDE: ${{ inputs.sdk-version }}
+        run: |
+          if [ -n "$SDK_VERSION_OVERRIDE" ]; then
+            ./build.sh UpdateSdkVersion --sdk-version-override "$SDK_VERSION_OVERRIDE"
+          else
+            ./build.sh UpdateSdkVersion
+          fi
+
+      - name: Open the update pull request
+        if: steps.sdk.outputs.sdk-update-available == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.AUTOMATION_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          SDK_VERSION: ${{ steps.sdk.outputs.sdk-version }}
+          PREVIOUS_SDK_VERSION: ${{ steps.sdk.outputs.previous-sdk-version }}
+        run: |
+          set -euo pipefail
+
+          branch="sdk-update/$SDK_VERSION"
+
+          if [ -n "$(gh pr list --state open --head "$branch" --json number --jq '.[].number')" ]; then
+            echo "A pull request for $SDK_VERSION is already open"
+            exit 0
+          fi
+
+          # A wave whose build never went green must not keep the next one from being proposed
+          for number in $(gh pr list --state open --json number,headRefName \
+            --jq '.[] | select(.headRefName | startswith("sdk-update/")) | .number'); do
+            gh pr close "$number" --comment "Superseded by the update to $SDK_VERSION." --delete-branch
+          done
+
+          cat > "$RUNNER_TEMP/pull-request-body.md" <<BODY
+          The JetBrains SDK moved from \`$PREVIOUS_SDK_VERSION\` to [\`$SDK_VERSION\`](https://www.nuget.org/packages/JetBrains.ReSharper.SDK/$SDK_VERSION).
+
+          Merging this publishes. An \`SdkVersion\` change landing on \`master\` runs the release path of the Build workflow, which pushes both plugins to JetBrains Marketplace and creates the GitHub release, and auto-merge is already enabled here.
+
+          When the build is red, the usual suspects are:
+
+          - [ ] binding redirects in \`test/src/app.config\` that the new SDK needs
+          - [ ] \`.gold\` expectations under \`test/data\` that moved with the SDK's rendering
+          - [ ] SDK API breaks in the analyzers, the suggestion providers and the options page
+          - [ ] the Rider frontend: the \`bundledModule\` line in \`build.gradle\`, the IntelliJ Platform Gradle Plugin, or the Gradle wrapper
+          BODY
+
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git switch --create "$branch"
+          git commit --all --message "Bump JetBrains SDK to $SDK_VERSION"
+          # Nothing but this workflow writes to sdk-update/*, and any leftover branch has no open
+          # pull request left by this point
+          git push --force --set-upstream origin "$branch"
+
+          gh pr create \
+            --base master \
+            --head "$branch" \
+            --title "Bump JetBrains SDK to $SDK_VERSION" \
+            --body-file "$RUNNER_TEMP/pull-request-body.md"
+
+          gh pr merge "$branch" --auto --squash --delete-branch

--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -31,7 +31,8 @@
         "PublishRiderPlugin",
         "Restore",
         "RunIde",
-        "Test"
+        "Test",
+        "UpdateSdkVersion"
       ]
     },
     "Verbosity": {
@@ -115,6 +116,10 @@
         "RunIdeSolution": {
           "type": "string",
           "description": "Solution to open in the sandboxed IDE"
+        },
+        "SdkVersionOverride": {
+          "type": "string",
+          "description": "Adopt this SDK version instead of the one the wave policy picks"
         },
         "Solution": {
           "type": "string",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,20 +41,29 @@ Default targets: `PackResharper`, `PackRider`.
 - **PackRider** - invokes `gradlew buildPlugin`, passing all Gradle properties on the command line; output goes to `gradle-build/distributions/*.zip`
 - **PublishReSharperPlugin** - `nuget push` of the packed `.nupkg` to `https://plugins.jetbrains.com/`
 - **PublishRiderPlugin** - `gradlew publishPlugin`; the Marketplace token goes through the `PUBLISH_TOKEN` environment variable rather than a `-P` property, because Nuke logs tool arguments
+- **UpdateSdkVersion** - adopts a newer JetBrains SDK in `Directory.Build.props`; see "Adopting a new SDK". Depends on nothing, so it neither restores nor compiles
 
-Both publish targets require `MarketplaceToken` and are only reached from a manually dispatched CI run. Sonar has no build target - analysis is server-side.
+Both publish targets require `MarketplaceToken`, and are reached either from a manually dispatched CI run or from an SDK bump landing on `master`. Sonar has no build target - analysis is server-side.
 
 Both pack targets call `PublishExtensionVersion()`, which reports the version to the Nuke summary and, under GitHub Actions, exports `EXTENSION_VERSION` to `$GITHUB_ENV` so the artifact upload steps can name the packages.
 
 ### Version derivation
 
-`SdkVersion` in the root `Directory.Build.props` is the single source of truth (e.g. `2026.2.1`). `Build.OnBuildInitialized` reads it off the solution and derives everything else from it:
+`SdkVersion` in the root `Directory.Build.props` is the single source of truth (e.g. `2026.2.1`). `Build.OnBuildInitialized` parses it straight out of that file with `XDocument` - deliberately not through `Solution.GetProperty`, because evaluating a `net472` project pulls in MSBuild and `UpdateSdkVersion` runs on a Linux runner - and derives everything else from it:
 
 - **Extension version** = `SdkVersion` locally; on GitHub Actions the run number is spliced in before any prerelease suffix, so `2025.1.0-eap02` becomes `2025.1.0.373-eap02`
 - **Wave version** for the nuspec dependency = digits pulled out of the SDK version by regex (`2026.2.x` produces `262.0`)
-- **Rider `ProductVersion`** = SDK version with trailing `.0` trimmed, plus a `-SNAPSHOT` suffix mangling for EAP versions
+- **Rider `ProductVersion`** = SDK version with a trailing `.0` dropped (`2025.1.0` is `2025.1` there, `2026.2.1` stays), plus `-EAP<n>-SNAPSHOT` for a prerelease. The suffix digits are re-parsed one number at a time, so `-eap10` does not collapse onto `-EAP1`
 
 Bumping the SDK therefore only requires editing `Directory.Build.props`.
+
+### Adopting a new SDK
+
+The `SDK update` workflow polls nuget.org daily and proposes the bump itself. `build.cmd UpdateSdkVersion` is what it runs: the target reads the versions published for all four SDK packages, keeps only those every one of them has, and picks a target under the wave policy. While the adopted version is stable only a higher wave qualifies, because a same-wave patch is already covered by the `Wave` dependency range the package declares; once it is a prerelease the whole train is followed, `eap01` through `rc01` to the stable release that closes the wave. `--sdk-version-override <version>` adopts a specific version instead, which is the way to take a same-wave patch.
+
+The workflow then commits the bump to `sdk-update/<version>`, opens a pull request with auto-merge enabled, and lets `Build and test` decide. Green merges to `master`, which publishes; red leaves the pull request open, which is the normal outcome for a wave change. Expect to fix binding redirects in `test/src/app.config`, `.gold` expectations, SDK API breaks, and sometimes `build.gradle` (the `bundledModule` line especially) and the Gradle wrapper. A stale red pull request is closed as superseded when the next version comes along.
+
+Opening that pull request needs the `AUTOMATION_TOKEN` repository secret, a fine-grained personal access token for this repository with read and write access to contents and pull requests. A pull request opened with the built-in `GITHUB_TOKEN` never triggers a workflow, so `Build and test` would never report and auto-merge would wait forever. To drive the flow without waiting for JetBrains, dispatch it with `-f sdk-version=<version>`.
 
 ### Toolchain constraints
 
@@ -206,7 +215,9 @@ structured-logging sidesteps both by keeping its scratch solutions in `test/manu
 
 GitHub Actions (`.github/workflows/build.yml`), `windows-2025`, .NET 10 and Temurin 21. On every push and pull request against `master` it runs `build.cmd Test --configuration Release`, then `build.cmd PackResharper PackRider --configuration Release`, and uploads the NUnit result files, the `.nupkg` and the Rider `.zip` as run artifacts; the two packages are named after `EXTENSION_VERSION`.
 
-A manual `workflow_dispatch` with `publish: true` additionally runs the two publish targets and then cuts a GitHub release tagged with the extension version (`--prerelease` when the version carries an EAP suffix). That path needs the `JETBRAINS_MARKETPLACE_TOKEN` repository secret; nothing else in the workflow needs a secret.
+Publishing runs the two publish targets and then cuts a GitHub release tagged with the extension version (`--prerelease` when the version carries an EAP suffix). The `Decide whether to publish` step turns it on for a manual `workflow_dispatch` with `publish: true`, and also for a push to `master` that changes `SdkVersion` in `Directory.Build.props` - which is how an SDK update ships itself. That comparison is why the checkout uses `fetch-depth: 0`, and why `cancel-in-progress` is narrowed to pull requests: a publishing push must not be cancelled half way through. The path needs the `JETBRAINS_MARKETPLACE_TOKEN` repository secret.
+
+`.github/workflows/sdk-update.yml` proposes those SDK bumps daily - see "Adopting a new SDK". It is the only thing in CI that needs `AUTOMATION_TOKEN`.
 
 SonarQube analysis is **server-side** - the scanner does not run in CI, and there is no Sonar target in the Nuke build.
 

--- a/Resharper.ConfigurationSense.slnx
+++ b/Resharper.ConfigurationSense.slnx
@@ -4,6 +4,7 @@
     <File Path=".github/dependabot.yml" />
     <File Path=".github/workflows/build.yml" />
     <File Path=".github/workflows/dependabot-auto-merge.yml" />
+    <File Path=".github/workflows/sdk-update.yml" />
     <File Path="build.gradle" />
     <File Path="Directory.Build.props" />
     <File Path="README.md" />

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -1,8 +1,15 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text.Json;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using System.Xml.Linq;
 
 using DefaultNamespace;
+
+using NuGet.Versioning;
 
 using Nuke.Common;
 using Nuke.Common.CI;
@@ -30,12 +37,20 @@ class Build : NukeBuild
 
     protected override void OnBuildInitialized()
     {
-        // Since we use global package management for dependencies
-        // We just pick up the first solution
-        SdkVersion = Solution.Resharper_ConfigurationSense.GetProperty("SdkVersion");
+        // Read straight from the props file rather than through Solution.GetProperty: evaluating a
+        // net472 project pulls in MSBuild, and UpdateSdkVersion runs on a Linux runner
+        SdkVersion = XDocument
+            .Load((RootDirectory / "Directory.Build.props").ToString())
+            .Descendants()
+            .Single(x => x.Name.LocalName == "SdkVersion")
+            .Value;
         SdkVersion.NotNull("Unable to detect SDK version");
 
-        var versionMatch = Regex.Match(SdkVersion, @"(?<version>[\d\.]+)(?<suffix>-.*)?");
+        var versionMatch = Regex.Match(
+            SdkVersion,
+            @"(?<version>[\d\.]+)(?<suffix>-.*)?",
+            RegexOptions.None,
+            RegexTimeout);
 
         SdkVersionWithoutSuffix = versionMatch.Groups["version"]
             .ToString();
@@ -46,7 +61,7 @@ class Build : NukeBuild
         ExtensionVersion = GitHubActions == null
             ? SdkVersion
             : $"{SdkVersionWithoutSuffix}.{GitHubActions.RunNumber}{SdkVersionSuffix}";
-        var sdkMatch = Regex.Match(SdkVersion, @"\d{2}(\d{2}).(\d).*");
+        var sdkMatch = Regex.Match(SdkVersion, @"\d{2}(\d{2}).(\d).*", RegexOptions.None, RegexTimeout);
         WaveMajorVersion = int.Parse(sdkMatch.Groups[1]
             .Value + sdkMatch.Groups[2]
             .Value);
@@ -63,9 +78,25 @@ class Build : NukeBuild
 
     [Parameter("Solution to open in the sandboxed IDE")] readonly AbsolutePath RunIdeSolution;
 
+    [Parameter("Adopt this SDK version instead of the one the wave policy picks")] readonly string SdkVersionOverride;
+
     [Solution(GenerateProjects = true)] readonly Solution Solution;
 
     [LocalPath("./gradlew.bat")] readonly Tool Gradle;
+
+    // Every regex here runs over a version string of a couple of dozen characters, so the bound is
+    // only ever reached by a runaway
+    static readonly TimeSpan RegexTimeout = TimeSpan.FromSeconds(1);
+
+    // Every project pins its SDK package to $(SdkVersion), and JetBrains does not always push the
+    // four of them at the same minute, so a version counts as available only once all of them have it
+    static readonly string[] SdkPackageIds =
+    {
+        "jetbrains.resharper.sdk",
+        "jetbrains.rider.sdk",
+        "jetbrains.resharper.sdk.tests",
+        "jetbrains.rider.sdk.tests",
+    };
 
     bool ExtensionVersionReported;
 
@@ -92,10 +123,23 @@ class Build : NukeBuild
     {
         get
         {
-            var productVersion = SdkVersionWithoutSuffix.TrimEnd('.', '0');
+            // A zero patch is dropped, so 2025.1.0 is 2025.1 there, but 2026.2.1 stays as it is
+            var productVersion = SdkVersionWithoutSuffix.EndsWith(".0", StringComparison.Ordinal)
+                ? SdkVersionWithoutSuffix.Substring(0, SdkVersionWithoutSuffix.Length - ".0".Length)
+                : SdkVersionWithoutSuffix;
+
             if (!string.IsNullOrEmpty(SdkVersionSuffix))
             {
-                productVersion += $"{SdkVersionSuffix.Replace("0", string.Empty).ToUpper()}-SNAPSHOT";
+                // -eap01 is -EAP1 there. The leading zeros go one number at a time, so that -eap10
+                // does not collapse onto -EAP1
+                var suffix = Regex.Replace(
+                    SdkVersionSuffix,
+                    @"\d+",
+                    x => int.Parse(x.Value)
+                        .ToString(),
+                    RegexOptions.None,
+                    RegexTimeout);
+                productVersion += $"{suffix.ToUpperInvariant()}-SNAPSHOT";
             }
 
             return productVersion;
@@ -224,6 +268,94 @@ class Build : NukeBuild
             Gradle(arguments, logger: RunIdeLogger);
         });
 
+    Target UpdateSdkVersion => _ => _
+        .Executes(async () =>
+        {
+            var availableVersions = await GetPublishedSdkVersions();
+            var currentVersion = NuGetVersion.Parse(SdkVersion);
+
+            NuGetVersion targetVersion;
+            if (SdkVersionOverride != null)
+            {
+                var requestedVersion = NuGetVersion.Parse(SdkVersionOverride);
+                targetVersion = availableVersions
+                    .FirstOrDefault(x => x.Equals(requestedVersion))
+                    .NotNull($"{SdkVersionOverride} is not published for every JetBrains SDK package");
+            }
+            else
+            {
+                targetVersion = SelectSdkUpdate(currentVersion, availableVersions);
+            }
+
+            if (targetVersion == null || targetVersion.Equals(currentVersion))
+            {
+                Log.Information("The JetBrains SDK {Version} is up to date", SdkVersion);
+                PublishGitHubOutput("sdk-update-available", "false");
+
+                return;
+            }
+
+            var propsFile = RootDirectory / "Directory.Build.props";
+            // A regex rather than XDocument.Save, so that the MSBuild namespace declaration, the
+            // attribute order and the comment in the file all survive untouched
+            propsFile.WriteAllText(Regex.Replace(
+                propsFile.ReadAllText(),
+                "<SdkVersion>[^<]*</SdkVersion>",
+                $"<SdkVersion>{targetVersion}</SdkVersion>",
+                RegexOptions.None,
+                RegexTimeout));
+
+            Log.Information("Updated the JetBrains SDK from {Current} to {Target}", SdkVersion, targetVersion);
+            ReportSummary(_ => _.AddPair("SDK", $"{SdkVersion} -> {targetVersion}"));
+
+            PublishGitHubOutput("sdk-update-available", "true");
+            PublishGitHubOutput("sdk-version", targetVersion.ToString());
+            PublishGitHubOutput("previous-sdk-version", SdkVersion);
+        });
+
+    static async Task<IReadOnlyCollection<NuGetVersion>> GetPublishedSdkVersions()
+    {
+        using var client = new HttpClient();
+
+        HashSet<NuGetVersion> versions = null;
+        foreach (var packageId in SdkPackageIds)
+        {
+            var index = await client.GetStringAsync($"https://api.nuget.org/v3-flatcontainer/{packageId}/index.json");
+
+            using var document = JsonDocument.Parse(index);
+            var published = document.RootElement
+                .GetProperty("versions")
+                .EnumerateArray()
+                .Select(x => NuGetVersion.Parse(x.GetString()))
+                .ToList();
+
+            if (versions == null)
+            {
+                versions = new HashSet<NuGetVersion>(published, VersionComparer.Default);
+            }
+            else
+            {
+                versions.IntersectWith(published);
+            }
+        }
+
+        return versions;
+    }
+
+    // A same wave patch is already covered by the Wave dependency range the package declares, so it
+    // is not worth a release; the next wave is, and it shows up as an EAP first. Once the adopted
+    // version is a prerelease the whole train is followed instead: eap01 -> rc01 -> the stable release
+    static NuGetVersion SelectSdkUpdate(NuGetVersion currentVersion, IEnumerable<NuGetVersion> availableVersions)
+    {
+        return availableVersions
+            .Where(x => x > currentVersion)
+            .Where(x => currentVersion.IsPrerelease
+                        || x.Major > currentVersion.Major
+                        || (x.Major == currentVersion.Major && x.Minor > currentVersion.Minor))
+            .OrderBy(x => x)
+            .LastOrDefault();
+    }
+
     // Both test projects share test/src, so each one writes to bin/<project>/<configuration>.
     // Extensions.GetOutputDirectory hardcodes bin/<configuration> and cannot be used here
     AbsolutePath TestOutputDirectory(Project project) =>
@@ -270,5 +402,13 @@ class Build : NukeBuild
 
         ExtensionVersionReported = true;
         GitHubActions.StepSummaryFile?.AppendAllLines(new[] { $"### Version `{ExtensionVersion}`" });
+    }
+
+    // Hands a value to the later steps of the same job, which is how the SDK update workflow learns
+    // what UpdateSdkVersion decided. Outside of GitHub Actions there is nowhere to write it
+    static void PublishGitHubOutput(string name, string value)
+    {
+        var outputFile = (AbsolutePath)GetVariable("GITHUB_OUTPUT");
+        outputFile?.AppendAllLines(new[] { $"{name}={value}" });
     }
 }


### PR DESCRIPTION
Ports the SDK update automation from [resharper-structured-logging#179](https://github.com/olsh/resharper-structured-logging/pull/179). `SdkVersion` cannot be Dependabot-managed, because the four SDK packages are pinned to `$(SdkVersion)` rather than to a literal, so every bump has been hand-driven and a new EAP sits unnoticed until someone looks.

### What it does

- **`UpdateSdkVersion` NUKE target** reads the versions published for all four SDK packages, keeps only those every one of them has, and picks a target under the wave policy: while the adopted version is stable only a higher wave qualifies, since a same-wave patch is already covered by the `Wave` dependency range the package declares; once it is a prerelease the whole `eap01` → `rc01` → stable train is followed. `--sdk-version-override <version>` adopts a specific version, which is how to take a same-wave patch. Only the `<SdkVersion>` line is rewritten, by regex, so the namespace declaration and the comment survive.
- **`SDK update` workflow** polls nuget.org daily, commits to `sdk-update/<version>`, closes any older SDK pull request as superseded, opens the pull request and enables auto-merge. It enables auto-merge itself, because `dependabot-auto-merge.yml` only ever acts on `dependabot[bot]`.
- **`Build` workflow** gains a `Decide whether to publish` step: an `SdkVersion` change landing on `master` is now a release, so a green bump ships itself. `cancel-in-progress` is narrowed to pull requests so a publishing push is not cancelled half way through.

### Two changes that came along

`OnBuildInitialized` now parses `Directory.Build.props` with `XDocument` instead of `Solution.GetProperty` — evaluating a `net472` project pulls in MSBuild, and the new target runs on `ubuntu-latest`.

`RiderProductVersion` had two latent bugs that automated EAP adoption makes reachable: `TrimEnd('.', '0')` turned `2026.2.10` into `2026.2.1`, and `Replace("0", "")` collapsed `-eap10` onto `-EAP1`. Diffed old against new across seven inputs: identical for everything that has shipped (`2026.2.1`, `2025.1.0`, `-eap01`, `-rc01`), differing only on those broken cases.

### Verification

All four target paths behave — no-op on the current version, wave policy finds nothing (no 2026.3 EAP yet), the write path touches only the `SdkVersion` line, and an unpublished version is rejected. The publish decision was exercised against real commits across six event shapes (dispatch, SDK change on `master`, no change, branch creation, pull request, non-`master` push) and each returned the right answer. Both test suites pass, both packages pack, and the artifacts still carry `since-build="262"`, `Wave 262.0.0` and version `2026.2.1`.

### Note

Needs the `AUTOMATION_TOKEN` repository secret, already set. A pull request opened with the built-in `GITHUB_TOKEN` never triggers a workflow, so `Build and test` would never report and auto-merge would wait forever.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automated JetBrains SDK update checks with scheduled and manual runs.
  - Added support for selecting or overriding an SDK version and opening an auto-mergeable update pull request.
  - Builds now publish packages and create releases when manually requested or when SDK changes reach `master`.

- **Documentation**
  - Documented SDK update workflows, version handling, and publishing conditions.

- **Improvements**
  - Improved version parsing and prerelease handling for more reliable SDK updates and releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->