### PR TITLE
Bump JetBrains SDK to 2026.3.0-eap01

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <SdkVersion>2026.2.1</SdkVersion>
+    <SdkVersion>2026.3.0-eap01</SdkVersion>
   </PropertyGroup>
   <!-- https://jetbrains.slack.com/archives/CBZ36NH7C/p1628090127002200 -->
   <PropertyGroup>

--- a/src/Resharper.ConfigurationSense/Models/KeyValueSettingLookupItem.cs
+++ b/src/Resharper.ConfigurationSense/Models/KeyValueSettingLookupItem.cs
@@ -19,7 +19,7 @@ namespace Resharper.ConfigurationSense.Models
 
         protected override RichText GetDisplayName()
         {
-            var displayName = LookupUtil.FormatLookupString($"{_keyValueSetting.Key} = ");
+            var displayName = LookupUtil.FormatLookupString($"{_keyValueSetting.Key} = ", TextColor);
             LookupUtil.AddInformationText(displayName, _keyValueSetting.Value);
 
             return displayName;

--- a/test/data/Completion/AppSettings/AppSettingsKey.cs.gold
+++ b/test/data/Completion/AppSettings/AppSettingsKey.cs.gold
@@ -2,12 +2,13 @@
 Prefix: """
 Count: 2
 Focus: Hard
+Rules: [\w] => add_to_prefix
 Range: "var value = ConfigurationManager.AppSettings["♦"];"
                                                      ▲▲△
 
 ##### RELEVANCE SORT #####
 
-                            [FromSingleCompletion, FromLightAndDynamicEvaluation, PrefixNoCaseMatch, NotObsolete, ObsoleteRuleApplied, NormalSelectionPriority, Other]
+                            [FromLightEvaluation, PrefixNoCaseMatch, NotObsolete, ObsoleteRuleApplied, NormalSelectionPriority, Other]
 F̣irstSetting =  |1          <==
 ṢecondSetting =  |2
 

--- a/test/data/Completion/ConnectionStrings/ConnectionStringName.cs.gold
+++ b/test/data/Completion/ConnectionStrings/ConnectionStringName.cs.gold
@@ -2,12 +2,13 @@
 Prefix: """
 Count: 2
 Focus: Hard
+Rules: [\w] => add_to_prefix
 Range: "var value = ConfigurationManager.ConnectionStrings["♦"];"
                                                            ▲▲△
 
 ##### RELEVANCE SORT #####
 
-                            [FromSingleCompletion, FromLightAndDynamicEvaluation, PrefixNoCaseMatch, NotObsolete, ObsoleteRuleApplied, NormalSelectionPriority, Other]
+                            [FromLightEvaluation, PrefixNoCaseMatch, NotObsolete, ObsoleteRuleApplied, NormalSelectionPriority, Other]
 F̣irstConnection =  |Data Source=first    <==
 ṢecondConnection =  |Data Source=second
 

--- a/test/data/Completion/MergedXmlSettings/MergedValues.cs.gold
+++ b/test/data/Completion/MergedXmlSettings/MergedValues.cs.gold
@@ -2,12 +2,13 @@
 Prefix: """
 Count: 1
 Focus: Hard
+Rules: [\w] => add_to_prefix
 Range: "var value = ConfigurationManager.AppSettings["♦"];"
                                                      ▲▲△
 
 ##### RELEVANCE SORT #####
 
-                            [FromSingleCompletion, FromLightAndDynamicEvaluation, PrefixNoCaseMatch, NotObsolete, ObsoleteRuleApplied, NormalSelectionPriority, Other]
+                            [FromLightEvaluation, PrefixNoCaseMatch, NotObsolete, ObsoleteRuleApplied, NormalSelectionPriority, Other]
 ṢharedSetting =  |from app.config, from web.config    <==
 
 ##### ALPHABETIC SORT #####

--- a/test/data/Completion/NetCoreConfiguration/GetValueKey.cs.gold
+++ b/test/data/Completion/NetCoreConfiguration/GetValueKey.cs.gold
@@ -2,12 +2,13 @@
 Prefix: """
 Count: 3
 Focus: Hard
+Rules: [\w] => add_to_prefix
 Range: "var value = configuration.GetValue<string>("♦");"
                                                    ▲▲△
 
 ##### RELEVANCE SORT #####
 
-                            [FromSingleCompletion, FromLightAndDynamicEvaluation, PrefixNoCaseMatch, NotObsolete, ObsoleteRuleApplied, NormalSelectionPriority, Other]
+                            [FromLightEvaluation, PrefixNoCaseMatch, NotObsolete, ObsoleteRuleApplied, NormalSelectionPriority, Other]
 C̣onnectionStrings:FirstConnection =  |Data Source=first    <==
 F̣irstSetting =  |1
 Ṇested:Value =  |2

--- a/test/data/Completion/NetCoreConfiguration/IndexerKey.cs.gold
+++ b/test/data/Completion/NetCoreConfiguration/IndexerKey.cs.gold
@@ -2,12 +2,13 @@
 Prefix: """
 Count: 3
 Focus: Hard
+Rules: [\w] => add_to_prefix
 Range: "var value = configuration["♦"];"
                                   ▲▲△
 
 ##### RELEVANCE SORT #####
 
-                            [FromSingleCompletion, FromLightAndDynamicEvaluation, PrefixNoCaseMatch, NotObsolete, ObsoleteRuleApplied, NormalSelectionPriority, Other]
+                            [FromLightEvaluation, PrefixNoCaseMatch, NotObsolete, ObsoleteRuleApplied, NormalSelectionPriority, Other]
 C̣onnectionStrings:FirstConnection =  |Data Source=first    <==
 F̣irstSetting =  |1
 Ṇested:Value =  |2

--- a/test/data/Completion/NetCoreConnectionStrings/ConnectionStringName.cs.gold
+++ b/test/data/Completion/NetCoreConnectionStrings/ConnectionStringName.cs.gold
@@ -2,12 +2,13 @@
 Prefix: """
 Count: 1
 Focus: Hard
+Rules: [\w] => add_to_prefix
 Range: "var value = configuration.GetConnectionString("♦");"
                                                       ▲▲△
 
 ##### RELEVANCE SORT #####
 
-                            [FromSingleCompletion, FromLightAndDynamicEvaluation, PrefixNoCaseMatch, NotObsolete, ObsoleteRuleApplied, NormalSelectionPriority, Other]
+                            [FromLightEvaluation, PrefixNoCaseMatch, NotObsolete, ObsoleteRuleApplied, NormalSelectionPriority, Other]
 F̣irstConnection =  |Data Source=first    <==
 
 ##### ALPHABETIC SORT #####

--- a/test/data/Completion/NetCoreGetSection/SectionName.cs.gold
+++ b/test/data/Completion/NetCoreGetSection/SectionName.cs.gold
@@ -2,12 +2,13 @@
 Prefix: """
 Count: 5
 Focus: Hard
+Rules: [\w] => add_to_prefix
 Range: "var section = configuration.GetSection("♦");"
                                                ▲▲△
 
 ##### RELEVANCE SORT #####
 
-                            [FromSingleCompletion, FromLightAndDynamicEvaluation, PrefixNoCaseMatch, NotObsolete, ObsoleteRuleApplied, NormalSelectionPriority, Other]
+                            [FromLightEvaluation, PrefixNoCaseMatch, NotObsolete, ObsoleteRuleApplied, NormalSelectionPriority, Other]
 C̣onnectionStrings =  |{
   "FirstConnection": "Data Source=first"
 }    <==


### PR DESCRIPTION
The JetBrains SDK moved from `2026.2.1` to [`2026.3.0-eap01`](https://www.nuget.org/packages/JetBrains.ReSharper.SDK/2026.3.0-eap01).

Merging this publishes. An `SdkVersion` change landing on `master` runs the release path of the Build workflow, which pushes both plugins to JetBrains Marketplace and creates the GitHub release, and auto-merge is already enabled here.

When the build is red, the usual suspects are:

- [ ] binding redirects in `test/src/app.config` that the new SDK needs
- [ ] `.gold` expectations under `test/data` that moved with the SDK's rendering
- [ ] SDK API breaks in the analyzers, the suggestion providers and the options page
- [ ] the Rider frontend: the `bundledModule` line in `build.gradle`, the IntelliJ Platform Gradle Plugin, or the Gradle wrapper


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved setting displays so keys and equals signs retain the appropriate text color.
  - Improved completion suggestions by applying more accurate prefix handling and relevance ranking across configuration and connection string settings.

- **Chores**
  - Updated the shared SDK version to `2026.3.0-eap01`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->