### PR TITLE
Verify the Rider plugin in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,8 +111,20 @@ jobs:
           path: test/results/*.xml
           if-no-files-found: error
 
-      - name: Build and pack
-        run: .\build.cmd PackResharper PackRider --configuration Release
+      # VerifyRider depends on PackRider, so this packs and verifies in one NUKE run and
+      # keeps the plugin verifier ahead of the uploads and the publish step, which is what
+      # stops a plugin that fails verification from reaching Marketplace
+      - name: Build, pack and verify
+        run: .\build.cmd PackResharper VerifyRider --configuration Release
+
+      # The verifier report only reaches the log at Debug level, so keep a readable copy
+      - name: Upload plugin verifier report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: plugin-verifier-report-${{ env.EXTENSION_VERSION }}
+          path: gradle-build/reports/pluginVerifier/
+          if-no-files-found: warn
 
       - name: Upload ReSharper package
         uses: actions/upload-artifact@v7

--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -32,7 +32,8 @@
         "Restore",
         "RunIde",
         "Test",
-        "UpdateSdkVersion"
+        "UpdateSdkVersion",
+        "VerifyRider"
       ]
     },
     "Verbosity": {

--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,27 @@ dependencies {
 intellijPlatform {
     // No pluginConfiguration block on purpose: setting `name` there overwrites the <name> from
     // plugin.xml with rootProject.name, which is the slug rather than the display name
+    pluginVerification {
+        // failureLevel is left at its convention, so the build fails on compatibility problems,
+        // internal API and override-only API. Deprecated API is reported rather than fatal: it is
+        // a warning, not a break, and failing on it would hold a release and turn every sdk-update
+        // pull request red as soon as JetBrains deprecates anything. The verifier prints its
+        // verdict to the build log and writes the report uploaded by the workflow
+
+        // The plugin ID predates these rules and is what Marketplace already has, so it cannot be
+        // changed without orphaning every installed copy. Marketplace grandfathers long-existing
+        // plugins; the standalone verifier does not, and without this it rejects the plugin as
+        // structurally invalid and verifies nothing at all
+        freeArgs = ['-mute', 'ForbiddenPluginIdPrefix,TemplateWordInPluginId']
+
+        ides {
+            // The Rider the plugin was just built against, which is also the one it ships for.
+            // Anything else would download a second multi-gigabyte distribution the runner has no
+            // room for, and 'recommended' skips the EAP builds this needs to cover
+            current()
+        }
+    }
+
     publishing {
         token    = providers.environmentVariable('PUBLISH_TOKEN')
         channels = [PluginChannel]

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -214,6 +214,20 @@ class Build : NukeBuild
             PublishExtensionVersion();
         });
 
+    // The Kotlin compiler already warns about deprecated platform API, but every Gradle line is
+    // logged at Debug, so the warning sits among hundreds of others and nobody reads it. The
+    // verifier reports it as a verdict instead, and fails the build on anything that truly breaks
+    Target VerifyRider => _ => _
+        .DependsOn(PackRider)
+        .Executes(() =>
+        {
+            // Each interpolation hole has to stay space-free: NUKE quotes any hole that contains
+            // spaces, which would collapse the properties into a single argument
+            Gradle(
+                @$"verifyPlugin -PPluginVersion={ExtensionVersion} -PProductVersion={RiderProductVersion} -PDotNetOutputDirectory={Solution.Resharper_ConfigurationSense_Rider.GetOutputDirectory(Configuration)} -PDotNetProjectName={Solution.Resharper_ConfigurationSense_Rider.Name}",
+                logger: GradleLogger);
+        });
+
     Target PublishReSharperPlugin => _ => _
         .DependsOn(PackResharper)
         .Requires(() => MarketplaceToken)

--- a/src/rider/main/kotlin/com/jetbrains/rider/settings/ConfigurationSenseBundle.kt
+++ b/src/rider/main/kotlin/com/jetbrains/rider/settings/ConfigurationSenseBundle.kt
@@ -5,7 +5,7 @@ import org.jetbrains.annotations.Nls
 import org.jetbrains.annotations.NonNls
 import org.jetbrains.annotations.PropertyKey
 
-class ConfigurationSenseBundle : DynamicBundle(BUNDLE) {
+class ConfigurationSenseBundle : DynamicBundle(ConfigurationSenseBundle::class.java, BUNDLE) {
     companion object {
         @NonNls
         private const val BUNDLE = "messages.ConfigurationSenseBundle"


### PR DESCRIPTION
Ports the plugin verification added to Structured Logging in [olsh/resharper-structured-logging#181](https://github.com/olsh/resharper-structured-logging/pull/181).

That plugin shipped a deprecated API usage that only surfaced in Marketplace verification, *after* the build was published. Nothing in the build would have caught it — the Kotlin compiler warns, but every Gradle line goes through the NUKE logger at Debug, so the warning sits among hundreds of others. This plugin has the same exposure, and an `SdkVersion` change on `master` publishes automatically.

## Changes

- **`VerifyRider` NUKE target**, depending on `PackRider`, using the existing `GradleLogger`.
- **Workflow**: `PackResharper PackRider` becomes `PackResharper VerifyRider`, so packaging and verification happen in one NUKE run — a separate step would enter the packaging target twice. It sits ahead of the uploads and the publish step, so a plugin that fails verification never reaches Marketplace.
- **`failureLevel` left at its convention**: the build fails on compatibility problems, internal API and override-only API, and only *reports* deprecated API. A deprecation is a warning, not a break, and failing on it would hold a release and turn every `sdk-update` PR red as soon as JetBrains deprecates anything.
- **`ides { current() }`** verifies against the Rider the plugin was just built against — `recommended()` would pull extra IDEs and skip EAPs, and an explicit version means a second multi-gigabyte download.
- The verifier report is uploaded as an artifact.

## The plugin ID has to be muted

`com.intellij.resharper.ConfigurationSense` trips three of the verifier's naming rules — the `com.intellij` prefix, and the words `intellij` and `resharper`. Without `-mute` the verifier rejects the plugin as structurally invalid and reports `Scheduled verifications (0)`, failing the build while checking nothing. That was confirmed on the Structured Logging PR, where the identical ID pattern produced exactly that.

The ID cannot change without orphaning every installed copy. Marketplace grandfathers long-existing plugins; the standalone verifier does not, which is why Marketplace verifies these plugins fine while the verifier will not read them.

## Validation

`VerifyRider -> PackRider` is registered and `Build.cs` compiles (`build.cmd --help`). The verification itself runs here for the first time — if this plugin has a deprecated API usage of its own, it will show up in the log and the report artifact without failing the build, which is the intended behaviour.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved release validation for compatibility with the current Rider version before packages are uploaded or published.
  * Added automated plugin verification to help identify packaging and compatibility issues earlier.
  * Verification reports are now preserved for review, including when validation encounters an issue or no report is generated.
  * Updated build tooling and release workflows to support the additional verification step.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->